### PR TITLE
Passing filepath to the Pug compiler to allow using relative paths

### DIFF
--- a/src/PugCompiler.php
+++ b/src/PugCompiler.php
@@ -37,7 +37,7 @@ class PugCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compile($path) {
 		if (is_null($this->cachePath)) return;
-		$contents = $this->pug->compile($this->files->get($path));
+		$contents = $this->pug->compile($this->files->get($path), $path);
 		$this->files->put($this->getCompiledPath($path), $contents);
 	}
 


### PR DESCRIPTION
Using leading slash to using Jade's extend breaks code completion in IDE's.
<img width="325" alt="jade-phpstorm" src="https://cloud.githubusercontent.com/assets/724423/24368154/0c0f589a-1328-11e7-9808-4f5a9ec3ffd4.png">
But we could simply pass filepath to the Pug compiler, and get opportunity to write relative paths.