### PR TITLE
Refactoring tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.2",
-        "phpunit/phpunit": "^4.8 || ^5.7",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "phpunit/php-code-coverage": "^2.2 || ^4.0 || ^5.2",
         "codeclimate/php-test-reporter": "^0.4.0"
     },

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -16,6 +16,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
+use PHPUnit\Framework\TestCase;
 
 include_once __DIR__ . '/helpers.php';
 
@@ -284,7 +285,7 @@ class Laravel4ServiceProvider extends ServiceProvider
 /**
  * @coversDefaultClass \Bkwld\LaravelPug\ServiceProvider
  */
-class BladeDirectivesTest extends \PHPUnit_Framework_TestCase
+class BladeDirectivesTest extends TestCase
 {
     /**
      * @var LaravelTestApp

--- a/tests/InstallTest.php
+++ b/tests/InstallTest.php
@@ -4,6 +4,7 @@ namespace Phug\Test;
 
 use Bkwld\LaravelPug\Install;
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 class Io
@@ -57,7 +58,7 @@ class Event
 /**
  * @coversDefaultClass \Bkwld\LaravelPug\Install
  */
-class InstallTest extends \PHPUnit_Framework_TestCase
+class InstallTest extends TestCase
 {
     /**
      * @covers ::getVersion

--- a/tests/InstallTest.php
+++ b/tests/InstallTest.php
@@ -83,7 +83,7 @@ class InstallTest extends TestCase
 
         self::assertSame('artisan config:publish bkwld/laravel-pug', $argv);
 
-        self::assertSame([
+        self::assertArraySubset([
             'app/config/app.php not found, please add Bkwld\LaravelPug\ServiceProvider::class, in it in your providers.',
             '> php artisan config:publish bkwld/laravel-pug' . "\nOK",
         ], $io->getMessages());
@@ -110,7 +110,7 @@ class InstallTest extends TestCase
 
         unlink('app/config/app.php');
 
-        self::assertSame([
+        self::assertArraySubset([
             'Pug service provided added to your app.',
             '> php artisan config:publish bkwld/laravel-pug' . "\nOK",
         ], $io->getMessages());
@@ -147,7 +147,7 @@ class InstallTest extends TestCase
 
         unlink('app/config/app.php');
 
-        self::assertSame([
+        self::assertArraySubset([
             'Pug service provided added to your app.',
             '> php artisan config:publish bkwld/laravel-pug' . "\nOK",
         ], $io->getMessages());
@@ -191,7 +191,7 @@ class InstallTest extends TestCase
             str_replace('"', '', $argv)
         );
 
-        self::assertSame([
+        self::assertArraySubset([
             'config/app.php not found, please add Bkwld\LaravelPug\ServiceProvider::class, in it in your providers.',
             '> php artisan vendor:publish --provider="Bkwld\LaravelPug\ServiceProvider"' . "\nOK",
         ], $io->getMessages());
@@ -218,7 +218,7 @@ class InstallTest extends TestCase
 
         unlink('config/app.php');
 
-        self::assertSame([
+        self::assertArraySubset([
             'Pug service provided added to your app.',
             '> php artisan vendor:publish --provider="Bkwld\LaravelPug\ServiceProvider"' . "\nOK",
         ], $io->getMessages());
@@ -250,10 +250,9 @@ class InstallTest extends TestCase
             str_replace('"', '', $argv)
         );
 
-        self::assertSame([
+        self::assertArraySubset([
             "config/app.php does not contain 'providers' => [], " .
             'please add a providers list with Bkwld\LaravelPug\ServiceProvider::class in it.',
-
             '> php artisan vendor:publish --provider="Bkwld\LaravelPug\ServiceProvider"' .
             "\nOK",
         ], $io->getMessages());

--- a/tests/InstallTest.php
+++ b/tests/InstallTest.php
@@ -100,9 +100,9 @@ class InstallTest extends TestCase
 
         $diff = '';
         try {
-            self::assertSame(
-                file_get_contents('app/config/laravel-4-app-config.php'),
-                file_get_contents('app/config/app.php')
+            self::assertFileEquals(
+                'app/config/laravel-4-app-config.php',
+                'app/config/app.php'
             );
         } catch (\PHPUnit_Framework_ExpectationFailedException $exception) {
             $diff = $exception->getComparisonFailure()->getDiff();
@@ -137,9 +137,9 @@ class InstallTest extends TestCase
 
         $diff = '';
         try {
-            self::assertSame(
-                file_get_contents('app/config/missing-comma-config.php'),
-                file_get_contents('app/config/app.php')
+            self::assertFileEquals(
+                'app/config/missing-comma-config.php',
+                'app/config/app.php'
             );
         } catch (\PHPUnit_Framework_ExpectationFailedException $exception) {
             $diff = $exception->getComparisonFailure()->getDiff();
@@ -208,9 +208,9 @@ class InstallTest extends TestCase
 
         $diff = '';
         try {
-            self::assertSame(
-                file_get_contents('config/laravel-5-app-config.php'),
-                file_get_contents('config/app.php')
+            self::assertFileEquals(
+                'config/laravel-5-app-config.php',
+                'config/app.php'
             );
         } catch (\PHPUnit_Framework_ExpectationFailedException $exception) {
             $diff = $exception->getComparisonFailure()->getDiff();

--- a/tests/PugBladeCompilerTest.php
+++ b/tests/PugBladeCompilerTest.php
@@ -4,6 +4,7 @@ namespace Phug\Test;
 
 use Bkwld\LaravelPug\PugBladeCompiler;
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 class PugBladeCompilerGetAndSetPath extends PugBladeCompiler
@@ -24,7 +25,7 @@ class PugBladeCompilerGetAndSetPath extends PugBladeCompiler
 /**
  * @coversDefaultClass \Bkwld\LaravelPug\PugBladeCompiler
  */
-class PugBladeCompilerTest extends \PHPUnit_Framework_TestCase
+class PugBladeCompilerTest extends TestCase
 {
     /**
      * @covers ::getOption

--- a/tests/PugCompilerTest.php
+++ b/tests/PugCompilerTest.php
@@ -4,6 +4,7 @@ namespace Phug\Test;
 
 use Bkwld\LaravelPug\PugCompiler;
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 use Pug\Pug;
 
 class PugCompilerGetAndSetPath extends PugCompiler
@@ -24,7 +25,7 @@ class PugCompilerGetAndSetPath extends PugCompiler
 /**
  * @coversDefaultClass \Bkwld\LaravelPug\PugCompiler
  */
-class PugCompilerTest extends \PHPUnit_Framework_TestCase
+class PugCompilerTest extends TestCase
 {
     /**
      * @covers ::isExpired

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -480,7 +480,7 @@ class ServiceProviderTest extends TestCase
      */
     public function testProvides()
     {
-        self::assertSame([
+        self::assertArraySubset([
             'Bkwld\LaravelPug\PugCompiler',
             'Bkwld\LaravelPug\PugBladeCompiler',
             'laravel-pug.pug',
@@ -503,7 +503,7 @@ class ServiceProviderTest extends TestCase
         $this->provider->register();
         $this->provider->boot();
 
-        self::assertSame(
+        self::assertArraySubset(
             ["pug","pug.php","jade","jade.php","pug.blade","pug.blade.php","jade.blade","jade.blade.php"],
             $view->getExtensions()
         );
@@ -524,7 +524,7 @@ class ServiceProviderTest extends TestCase
         $provider->register();
         $provider->boot();
 
-        self::assertSame(
+        self::assertArraySubset(
             ["pug","pug.php","jade","jade.php","pug.blade","pug.blade.php","jade.blade","jade.blade.php"],
             $view->getExtensions()
         );

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\View\Engines\CompilerEngine;
+use PHPUnit\Framework\TestCase;
 use Pug\Assets;
 
 include_once __DIR__ . '/helpers.php';
@@ -344,7 +345,7 @@ class Resolver
 /**
  * @coversDefaultClass \Bkwld\LaravelPug\ServiceProvider
  */
-class ServiceProviderTest extends \PHPUnit_Framework_TestCase
+class ServiceProviderTest extends TestCase
 {
     /**
      * @var LaravelTestApp

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -389,9 +389,9 @@ class ServiceProviderTest extends TestCase
      */
     public function testRegister()
     {
-        self::assertSame(null, $this->app->getSingleton('laravel-pug.pug'));
-        self::assertSame(null, $this->app->getSingleton('Bkwld\LaravelPug\PugCompiler'));
-        self::assertSame(null, $this->app->getSingleton('Bkwld\LaravelPug\PugBladeCompiler'));
+        self::assertNull($this->app->getSingleton('laravel-pug.pug'));
+        self::assertNull($this->app->getSingleton('Bkwld\LaravelPug\PugCompiler'));
+        self::assertNull($this->app->getSingleton('Bkwld\LaravelPug\PugBladeCompiler'));
 
         $this->provider->register();
         /** @var \Pug\Pug $pug */
@@ -428,9 +428,9 @@ class ServiceProviderTest extends TestCase
         });
         $provider = new Laravel5ServiceProvider($app);
 
-        self::assertSame(null, $app->getSingleton('laravel-pug.pug'));
-        self::assertSame(null, $app->getSingleton('Bkwld\LaravelPug\PugCompiler'));
-        self::assertSame(null, $app->getSingleton('Bkwld\LaravelPug\PugBladeCompiler'));
+        self::assertNull($app->getSingleton('laravel-pug.pug'));
+        self::assertNull($app->getSingleton('Bkwld\LaravelPug\PugCompiler'));
+        self::assertNull($app->getSingleton('Bkwld\LaravelPug\PugBladeCompiler'));
 
         $provider->register();
         /** @var \Pug\Pug $pug */

--- a/tests/UpdateCheckTest.php
+++ b/tests/UpdateCheckTest.php
@@ -7,6 +7,7 @@ use Composer\Config as ComposerConfig;
 use Composer\Composer;
 use Composer\IO\NullIO;
 use Composer\Script\Event as ComposerEvent;
+use PHPUnit\Framework\TestCase;
 
 class CaptureIO extends NullIO
 {
@@ -31,7 +32,7 @@ class CaptureIO extends NullIO
 /**
 * @coversDefaultClass \Bkwld\LaravelPug\UpdateCheck
 */
-class UpdateCheckTest extends \PHPUnit_Framework_TestCase
+class UpdateCheckTest extends TestCase
 {
     private static function assertComposerSettingsTouchIO($directory, $touched)
     {


### PR DESCRIPTION
I've refactored some tests, using:

- [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertNull) instead of `assertSame(null, $condition)`;
- [`assertArraySubset`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertArraySubset) when comparing `arrays`;
- [`assertFileEquals`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileEquals) when comparing files.

I've also used `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.